### PR TITLE
fix bug when XML already contains CDATA tags

### DIFF
--- a/classes/File_IO.php
+++ b/classes/File_IO.php
@@ -128,6 +128,8 @@ class File_IO {
             if (move_uploaded_file($fileArrayValue['tmp_name'], $newFileName)) {
                 $fileContent = file_get_contents($newFileName);
                 if ($fileContent !== false) {
+                    $fileContent = str_replace('<![CDATA[', '', $fileContent);
+                    $fileContent = str_replace(']]>', '', $fileContent);
                     $fileContent = preg_replace('/<string-array([^>]*)>/i', '<entryList\1>', $fileContent);
                     $fileContent = str_replace('</string-array>', '</entryList>', $fileContent);
                     $fileContent = preg_replace('/<string([^>]*)>/i', '<entrySingle\1><![CDATA[', $fileContent);


### PR DESCRIPTION
If the XML file already contains CDATA tags, the script adds them again and the XML gets invalid, simplexml won't parse it.
